### PR TITLE
feat: add alternative versioning schemes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.iml
 node_modules
 /test-results.json
+/coverage
+.idea/
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ antora:
         - groupId: "com.example"      # required
           artifactId: "antora-module" # required
           version: "1.x.x"            # defaults to '*'
+          versionScheme: "SemVer"     # defaults to 'SemVer' 
           limit: 3                    # defaults to 1
           limitBy: minor              # defaults to 'major', one of 'major', 'minor', 'patch', 'any'
           includeSnapshots: true      # defaults to false, true has no effect if includePrerelease is false as SNAPSHOTS are SemVer pre releases
@@ -45,6 +46,7 @@ antora:
           extension: "tgz"            # defaults to 'zip'
           startPath: ~                # defaults to null
           startPaths: "docs/*"        # defaults to null
+          edit_url: "https://git.example.com/repos/myRepo/browse/{path}" # defaults to false
 # ...
 ```
 
@@ -71,6 +73,15 @@ For each picked version a corresponding playbook content source entry is created
 
 * points to a local transient cached on-demand git repository the artifact has been extracted to
 * is configured with the same [start path(s)](https://docs.antora.org/antora/3.0/playbook/content-source-start-paths/)
+* is configured with an [edit url](https://docs.antora.org/antora/latest/playbook/content-edit-url/)
+
+### Supported Versioning Schemes
+
+| Scheme | Structure | version format | notes
+| ---    | ----      | ----           | ---
+| [`SemVer`](https://semver.org/) | `<major>.<minor>.<patch>+<metadata>-<prerelease>` | any valid [SemVer Range](https://www.npmjs.com/package/semver#user-content-ranges) | recommended
+| [`OSGI`](https://www.eclipse.org/virgo/documentation/virgo-documentation-3.7.0.M01/docs/virgo-user-guide/html/ch02s02.html#d0e341) | `<major>.<minor>.<micro>.<qualifier>` | any valid [OSGI range](https://www.eclipse.org/virgo/documentation/virgo-documentation-3.7.0.M01/docs/virgo-user-guide/html/ch02s02.html#d0e404) | `micro` is exposed as `patch`, there is no order between qualifiers
+| `Lexicographically` | any | any valid regular expression | `minor` and `patch` are always `0`, the complete version is the `major` part
 
 ### Maven `settings.xml`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension allows [Antora](https://docs.antora.org/antora/3.0/) to retrieve 
 If parts of the documentation are generated or post-processed it's usually more convenient to package and publish the docs to a maven repository instead of making the build commit generated files into a git repo.
 Also, it's probably more common for Java hackers to refer to published artifacts than to git repos.
 
-WARNING: This extension expects maven artifacts to be versioned according to [SemVer](https://www.npmjs.com/package/semver)
+> This extension recommends maven artifacts to be versioned according to [SemVer](https://www.npmjs.com/package/semver)
 
 ## Usage
 
@@ -79,7 +79,7 @@ For each picked version a corresponding playbook content source entry is created
 
 | Scheme | Structure | version format | notes
 | ---    | ----      | ----           | ---
-| [`SemVer`](https://semver.org/) | `<major>.<minor>.<patch>+<metadata>-<prerelease>` | any valid [SemVer Range](https://www.npmjs.com/package/semver#user-content-ranges) | recommended
+| [`SemVer`](https://semver.org/) | `<major>.<minor>.<patch>+<metadata>-<prerelease>` | any valid [SemVer Range](https://www.npmjs.com/package/semver#ranges) | recommended
 | [`OSGI`](https://www.eclipse.org/virgo/documentation/virgo-documentation-3.7.0.M01/docs/virgo-user-guide/html/ch02s02.html#d0e341) | `<major>.<minor>.<micro>.<qualifier>` | any valid [OSGI range](https://www.eclipse.org/virgo/documentation/virgo-documentation-3.7.0.M01/docs/virgo-user-guide/html/ch02s02.html#d0e404) | `micro` is exposed as `patch`, there is no order between qualifiers
 | `Lexicographically` | any | any valid regular expression | `minor` and `patch` are always `0`, the complete version is the `major` part
 

--- a/lib/maven-client.js
+++ b/lib/maven-client.js
@@ -29,10 +29,10 @@ class MavenClient {
      */
     async downloadAndExtract(repository, targetFolder, mavenArtifact) {
         const downloadUrl = await MavenClient.#buildUrl(repository, mavenArtifact, this.logger)
-        this.logger.debug('Fetching ' + downloadUrl)
+        this.logger.debug(`Fetching ${downloadUrl} ...`)
         const response = await fetch(downloadUrl, repository.fetchOptions);
         if (!response.ok) {
-            throw new MavenClientError("Failure downloading " + downloadUrl + ' (' + response.status + ')');
+            throw new MavenClientError(`Failure downloading ${downloadUrl} (${response.status})`);
         }
         switch (mavenArtifact.extension) {
             case 'zip':
@@ -49,7 +49,7 @@ class MavenClient {
                 );
                 break;
             default:
-                throw new MavenClientError('Unsupported extension: ' + mavenArtifact.extension);
+                throw new MavenClientError(`Unsupported extension: ${mavenArtifact.extension}`);
         }
     }
 
@@ -84,37 +84,37 @@ class MavenClient {
         const versionToRepoMap = new Map();
         await Promise.all(repositories.map(async (repository) => {
             const metaDataUrl = MavenClient.#buildMetaDataUrlForArtifact(repository.baseUrl, {groupId, artifactId});
-            this.logger.debug('Downloading metadata to extract version from ' + metaDataUrl);
+            this.logger.debug(`Downloading metadata to extract version from ${metaDataUrl}`);
             try {
                 const metaDataFile = new MavenMetaDataFile(await MavenClient.#downloadXml(metaDataUrl, repository.fetchOptions), this.logger);
                 metaDataFile.getVersions().forEach(discoveredVersion => {
                     if (!versionScheme.valid(discoveredVersion)) {
-                        this.logger.info('Found invalid version ' + discoveredVersion + ' for ' + groupId + ':' + artifactId + ', skipping.');
+                        this.logger.info(`Found invalid version ${discoveredVersion} for ${groupId}:${artifactId}, skipping.`);
                     } else if (!versionToRepoMap.has(discoveredVersion)) {
                         versionToRepoMap.set(discoveredVersion, repository);
                     }
                 });
             } catch (error) {
-                this.logger.warn('Error when trying to fetch meta data for ' + groupId + ':' + artifactId + ' from ' + repository + ': ' + error.message);
+                this.logger.warn(`Error when trying to fetch meta data for ${groupId}:${artifactId} from ${repository}: ${error.message}`);
                 const fixedVersionUrl = await MavenClient.#buildUrl(
                     repository,
                     new MavenArtifact({groupId, artifactId, version, classifier, extension}))
-                this.logger.debug('Probing "' + fixedVersionUrl + '"...')
+                this.logger.debug(`Probing "${fixedVersionUrl}"...`)
                 if (await MavenClient.#existsRemotely(fixedVersionUrl, repository.fetchOptions)) {
-                    this.logger.debug('Using fallback version for ' + groupId + ':' + artifactId + ':' + version);
+                    this.logger.debug(`Using fallback version for ${groupId}:${artifactId}:${version}`);
                     versionToRepoMap.set(version, repository)
 
                 } else {
-                    this.logger.warn('Skipping ' + groupId + ':' + artifactId);
+                    this.logger.warn(`Skipping ${groupId}:${artifactId}`);
                 }
             }
         }));
         if (!versionToRepoMap.size) {
-            throw new MavenClientError('Unable to find any version for ' + groupId + ':' + artifactId);
+            throw new MavenClientError(`Unable to find any version for ${groupId}:${artifactId}`);
         }
         const versionList = versionScheme.sort([...versionToRepoMap.keys()]);
         versionList.reverse();
-        this.logger.info('Found ' + versionList.length + ' versions for ' + groupId + ':' + artifactId);
+        this.logger.info(`Found ${versionList.length} versions for ${groupId}:${artifactId}`);
         return versionList.map(version => {
             return {
                 version: version,
@@ -141,7 +141,7 @@ class MavenClient {
         const snapshotMetaData = new MavenMetaDataFile(await MavenClient.#downloadXml(snaphotMetadataUrl, repository.fetchOptions), logger);
         const latestVersion = snapshotMetaData.getLatestSnapshotVersion(mavenArtifact.classifier, mavenArtifact.extension);
         if (!latestVersion) {
-            throw new MavenClientError('Cannot find latest snapshot version info for ' + mavenArtifact.extension + ' in maven metadata: ' + snapshotMetaData)
+            throw new MavenClientError(`Cannot find latest snapshot version info for ${mavenArtifact.extension} in maven metadata: ${snapshotMetaData}`)
         }
         return [repository.baseUrl]
             .concat(...MavenClient.#groupIdAsPathSegments(mavenArtifact.groupId))
@@ -192,7 +192,7 @@ class MavenClient {
         let blob = await metaDataResponse.blob()
         let text = await blob.text();
         if (!metaDataResponse.ok) {
-            throw new MavenClientError("Failure while downloading xml file: " + metaDataResponse.status + " : " + text);
+            throw new MavenClientError(`Failure while downloading xml file: ${metaDataResponse.status} : ${text}`);
         }
         return text;
     }
@@ -209,9 +209,9 @@ class MavenClient {
     }
 
     async extractRepositoriesFromSettingsFile(settingsFilePath) {
-        this.logger.debug('Loading repositories from ' + settingsFilePath + '...');
+        this.logger.debug(`Loading repositories from ${settingsFilePath}...`);
         if (!fs.existsSync(settingsFilePath)) {
-            this.logger.warn('Skip loading repos from settings, ' + settingsFilePath + ' does not exist.');
+            this.logger.warn(`Skip loading repos from settings, ${settingsFilePath} does not exist.`);
             return [];
         }
         const mavenSettingsXml = await fs.promises.readFile(settingsFilePath, "utf-8")
@@ -228,7 +228,7 @@ class MavenClient {
         if (fs.existsSync(INSTALL_SETTINGS)) {
             return INSTALL_SETTINGS;
         }
-        throw new MavenClientError("Unable to find maven settings. Looked for: " + [USER_SETTINGS, INSTALL_SETTINGS]);
+        throw new MavenClientError(`Unable to find maven settings. Looked for: ${[USER_SETTINGS, INSTALL_SETTINGS]}`);
     }
 }
 

--- a/lib/maven-client.js
+++ b/lib/maven-client.js
@@ -7,10 +7,8 @@ const {
     MavenRepository,
     MavenArtifact
 } = require('./maven-types')
-const semver = require('semver')
 const {MavenSettingsFile, MavenMetaDataFile} = require("./maven-files");
 const Process = require("process");
-
 
 const META_DATA_FILE_NAME = 'maven-metadata.xml';
 
@@ -75,13 +73,14 @@ class MavenClient {
      * @param {MavenRepository[]} repositories
      * @param {string} groupId
      * @param {string} artifactId
+     * @param {object} versionScheme The versioning scheme from versioning.js
      * @param {string} version optional, try to find this if metadata discovery fails for a reason
      * @param {string} classifier optional, try to find this if metadata discovery fails for a reason
      * @param {string} extension optional, try to find this if metadata discovery fails for a reason
      *
      * @returns {Promise<{version, repository}[]>}
      */
-    async retrieveAvailableVersions(repositories, {groupId, artifactId, fallback: {version, classifier, extension}}) {
+    async retrieveAvailableVersions(repositories, versionScheme, {groupId, artifactId, fallback: {version, classifier, extension}}) {
         const versionToRepoMap = new Map();
         await Promise.all(repositories.map(async (repository) => {
             const metaDataUrl = MavenClient.#buildMetaDataUrlForArtifact(repository.baseUrl, {groupId, artifactId});
@@ -89,8 +88,8 @@ class MavenClient {
             try {
                 const metaDataFile = new MavenMetaDataFile(await MavenClient.#downloadXml(metaDataUrl, repository.fetchOptions), this.logger);
                 metaDataFile.getVersions().forEach(discoveredVersion => {
-                    if (!semver.valid(discoveredVersion)) {
-                        this.logger.info('Found invalid SemVer version ' + discoveredVersion + ' for ' + groupId + ':' + artifactId + ', skipping.');
+                    if (!versionScheme.valid(discoveredVersion)) {
+                        this.logger.info('Found invalid version ' + discoveredVersion + ' for ' + groupId + ':' + artifactId + ', skipping.');
                     } else if (!versionToRepoMap.has(discoveredVersion)) {
                         versionToRepoMap.set(discoveredVersion, repository);
                     }
@@ -113,7 +112,7 @@ class MavenClient {
         if (!versionToRepoMap.size) {
             throw new MavenClientError('Unable to find any version for ' + groupId + ':' + artifactId);
         }
-        const versionList = semver.sort([...versionToRepoMap.keys()]);
+        const versionList = versionScheme.sort([...versionToRepoMap.keys()]);
         versionList.reverse();
         this.logger.info('Found ' + versionList.length + ' versions for ' + groupId + ':' + artifactId);
         return versionList.map(version => {

--- a/lib/maven-content-source.js
+++ b/lib/maven-content-source.js
@@ -15,6 +15,7 @@ class MavenContentSource {
     #startPath;
     #startPaths;
     #logger;
+    #edit_url;
 
     toString() {
         return this.#mavenArtifact
@@ -32,7 +33,8 @@ class MavenContentSource {
                     cacheFolder,
                     logger,
                     startPath,
-                    startPaths
+                    startPaths,
+                    edit_url
                 }) {
         this.#mavenArtifact = mavenArtifact;
         this.#mavenClient = mavenClient;
@@ -42,6 +44,7 @@ class MavenContentSource {
         this.#logger = logger;
         this.#startPath = startPath;
         this.#startPaths = startPaths;
+        this.#edit_url = edit_url;
 
         if (!["zip", "jar", "tgz"].includes(this.#mavenArtifact.extension)) {
             throw new MavenContentSourceError('Unsupported extension "' + this.#mavenArtifact.extension + '", use one of zip, jar, tgz');
@@ -104,13 +107,17 @@ class MavenContentSource {
         if (!playbook.content.sources) playbook.content.sources = [];
         let antoraContentSource = {
             url: folder,
-            branches: 'HEAD'
+            branches: 'HEAD',
+            edit_url: false
         };
         if (this.#startPath) {
             antoraContentSource.start_path = this.#startPath;
         }
         if (this.#startPaths) {
             antoraContentSource.start_paths = this.#startPaths;
+        }
+        if (this.#edit_url) {
+            antoraContentSource.edit_url = this.#edit_url;
         }
         playbook.content.sources.push(antoraContentSource);
     }

--- a/lib/maven-types.js
+++ b/lib/maven-types.js
@@ -90,19 +90,14 @@ class MavenContentCoordinate {
     }
 
     toString() {
-        return 'MavenContentCoordinate(' + this.groupId + ':' + this.artifactId + ':[' + this.versionRange + ']'
-            + (this.classifier ? ':' + this.classifier : '')
-            + (this.extension ? '@' + this.extension : '')
-            + (limit !== 1 ? ', up to ' + limit + ' versions' : '')
-            + (this.includeSnapshots ? ' including ' : ' excluding ') + 'snapshots'
-            + ', selected by "' + this.regExp + '")';
+        return `MavenContentCoordinate(${this.groupId}:${this.artifactId}:[${this.versionRange}]${this.classifier ? ':' + this.classifier : ''}${this.extension ? '@' + this.extension : ''}${this.limit !== 1 ? ', up to ' + this.limit + ' versions' : ''}${this.includeSnapshots ? ' including ' : ' excluding '}snapshots, selected by "${this.limitBy}")`;
     }
 
     /**
      *
      * @param {MavenClient} mavenClient
      * @param {MavenRepository[]} repositories
-     * @param {Git} git
+     * @param git
      * @param {string} cacheFolder
      * @param logger
      * @returns {Promise<MavenContentSource[]>}
@@ -110,7 +105,7 @@ class MavenContentCoordinate {
     async resolveToContentSources(mavenClient, repositories, git, cacheFolder, logger) {
         let versionRepoTupleList = [];
         try {
-            versionRepoTupleList = await mavenClient.retrieveAvailableVersions(repositories, this.versionScheme,{
+            versionRepoTupleList = await mavenClient.retrieveAvailableVersions(repositories, this.versionScheme, {
                 groupId: this.groupId,
                 artifactId: this.artifactId,
                 fallback: {

--- a/lib/maven-types.js
+++ b/lib/maven-types.js
@@ -1,6 +1,6 @@
-const semver = require('semver')
 const MavenContentSource = require('./maven-content-source')
 const selectVersion = require('./version-selector');
+const versioning = require('./versioning')
 
 class MavenRepository {
     baseUrl;
@@ -51,11 +51,13 @@ class MavenContentCoordinate {
     includeSnapshots;
     startPath;
     startPaths;
+    edit_url;
 
     constructor({
                     groupId,
                     artifactId,
                     version = "*",
+                    versionScheme = 'SemVer',
                     classifier = 'docs',
                     extension = 'zip',
                     limit = 1,
@@ -63,7 +65,8 @@ class MavenContentCoordinate {
                     includeSnapshots = false,
                     startPath = null,
                     startPaths = null,
-                    includePrerelease = true
+                    includePrerelease = true,
+                    edit_url = false
                 }) {
         this.groupId = groupId;
         this.artifactId = artifactId;
@@ -71,7 +74,11 @@ class MavenContentCoordinate {
         this.startPath = startPath;
         this.startPaths = startPaths;
         this.version = version;
-        this.versionRange = new semver.Range(version, {loose: false, includePrerelease});
+        this.versionScheme = versioning[versionScheme];
+        if (!this.versionScheme) {
+            throw new TypeError(`versionScheme must be one of "${Object.keys(versioning).join('", "')}"`);
+        }
+        this.versionRange = this.versionScheme.range(version, includePrerelease);
         this.classifier = classifier;
         this.extension = extension;
         this.limit = limit;
@@ -79,6 +86,7 @@ class MavenContentCoordinate {
         if (!['major', 'minor', 'patch', 'any'].includes(this.limitBy)) {
             throw new TypeError("limitBy must be one of 'major', 'minor', 'patch', 'any'");
         }
+        this.edit_url = edit_url;
     }
 
     toString() {
@@ -102,7 +110,7 @@ class MavenContentCoordinate {
     async resolveToContentSources(mavenClient, repositories, git, cacheFolder, logger) {
         let versionRepoTupleList = [];
         try {
-            versionRepoTupleList = await mavenClient.retrieveAvailableVersions(repositories, {
+            versionRepoTupleList = await mavenClient.retrieveAvailableVersions(repositories, this.versionScheme,{
                 groupId: this.groupId,
                 artifactId: this.artifactId,
                 fallback: {
@@ -125,7 +133,7 @@ class MavenContentCoordinate {
 
     createSourcesForMatchingVersions(versionRepoTupleList, mavenClient, git, cacheFolder, logger) {
         let results = [];
-        selectVersion(this.versionRange, this.limit, this.limitBy, versionRepoTupleList, versionRepoTuple => {
+        selectVersion(this.versionScheme, this.versionRange, this.limit, this.limitBy, versionRepoTupleList, versionRepoTuple => {
             results.push(new MavenContentSource({
                     mavenClient: mavenClient,
                     logger: mavenClient.logger,
@@ -134,6 +142,7 @@ class MavenContentCoordinate {
                     cacheFolder: cacheFolder,
                     startPath: this.startPath,
                     startPaths: this.startPaths,
+                    edit_url: this.edit_url,
                     mavenArtifact: new MavenArtifact({
                         groupId: this.groupId,
                         artifactId: this.artifactId,
@@ -145,44 +154,6 @@ class MavenContentCoordinate {
             ))
         }, logger);
         return results;
-    }
-
-    /**
-     * @param {{repository: MavenRepository, version: string}[]} versionRepoTupleList
-     * @param {function({repository: MavenRepository, version: string})} consumer
-     * @param logger
-     */
-    forEachSelectedTuple(versionRepoTupleList, consumer, logger) {
-        let usedVersionFragments = new Set();
-        let idx = 0;
-        do {
-            let candidate = versionRepoTupleList[idx];
-            if (this.versionRange.test(candidate.version)) {
-                const candidateFragment = this.#extractVersionFragment(candidate.version);
-                if (!usedVersionFragments.has(candidateFragment)) {
-                    consumer(candidate);
-                    usedVersionFragments.add(candidateFragment);
-                } else {
-                    logger.debug('Skipping version ' + candidate.version + ' of ' + this + ': version fragment already present');
-                }
-            } else {
-                logger.debug('Skipping version ' + candidate.version + ' of ' + this + ': does not match ' + this.versionRange);
-            }
-        } while (++idx < versionRepoTupleList.length && usedVersionFragments.length < this.limit)
-    }
-
-    #extractVersionFragment(version) {
-        let semanticVersion = semver.parse(version);
-        switch (this.limitBy) {
-            case 'major':
-                return semanticVersion.major;
-            case 'minor':
-                return semanticVersion.major + '.' + semanticVersion.minor;
-            case 'patch':
-                return semanticVersion.major + '.' + semanticVersion.minor + '.' + semanticVersion.patch;
-            default:
-                return version;
-        }
     }
 }
 

--- a/lib/version-selector.js
+++ b/lib/version-selector.js
@@ -1,12 +1,4 @@
-function extractVersionFragment(versionScheme, version, fragment) {
-    let parsedVersion = versionScheme.parse(version);
-    switch (fragment) {
-        case 'major': return parsedVersion.major;
-        case 'minor': return parsedVersion.major + '.' + parsedVersion.minor;
-        case 'patch': return parsedVersion.major + '.' + parsedVersion.minor + '.' + parsedVersion.patch;
-        default: return version;
-    }
-}
+module.exports = selectVersions
 
 function selectVersions(versionScheme, versionRange, limit, limitBy, orderedVersionRepoTupleList, consumer, logger) {
     if (!orderedVersionRepoTupleList || !orderedVersionRepoTupleList.length) {
@@ -33,5 +25,12 @@ function selectVersions(versionScheme, versionRange, limit, limitBy, orderedVers
         }
     } while (++idx < orderedVersionRepoTupleList.length && usedVersionFragments.size < limit)
 }
-
-module.exports = selectVersions
+function extractVersionFragment(versionScheme, version, fragment) {
+    let parsedVersion = versionScheme.parse(version);
+    switch (fragment) {
+        case 'major': return parsedVersion.major;
+        case 'minor': return parsedVersion.major + '.' + parsedVersion.minor;
+        case 'patch': return parsedVersion.major + '.' + parsedVersion.minor + '.' + parsedVersion.patch;
+        default: return version;
+    }
+}

--- a/lib/version-selector.js
+++ b/lib/version-selector.js
@@ -1,29 +1,27 @@
-const semver = require("semver");
-
-function extractVersionFragment(version, fragment) {
-    let semanticVersion = semver.parse(version);
+function extractVersionFragment(versionScheme, version, fragment) {
+    let parsedVersion = versionScheme.parse(version);
     switch (fragment) {
-        case 'major': return semanticVersion.major;
-        case 'minor': return semanticVersion.major + '.' + semanticVersion.minor;
-        case 'patch': return semanticVersion.major + '.' + semanticVersion.minor + '.' + semanticVersion.patch;
+        case 'major': return parsedVersion.major;
+        case 'minor': return parsedVersion.major + '.' + parsedVersion.minor;
+        case 'patch': return parsedVersion.major + '.' + parsedVersion.minor + '.' + parsedVersion.patch;
         default: return version;
     }
 }
 
-function selectVersions(versionRange, limit, limitBy, orderedVersionRepoTupleList, consumer, logger) {
+function selectVersions(versionScheme, versionRange, limit, limitBy, orderedVersionRepoTupleList, consumer, logger) {
     if (!orderedVersionRepoTupleList || !orderedVersionRepoTupleList.length) {
         logger.debug('No version given.');
         return;
     }
     let usedVersionFragments = new Set();
     if (typeof versionRange === "string") {
-        versionRange = new semver.Range(versionRange);
+        versionRange = versionScheme.range(versionRange);
     }
     let idx = 0;
     do {
         let candidate = orderedVersionRepoTupleList[idx];
         if (versionRange.test(candidate.version)) {
-            const candidateFragment = extractVersionFragment(candidate.version, limitBy);
+            const candidateFragment = extractVersionFragment(versionScheme, candidate.version, limitBy);
             if (!usedVersionFragments.has(candidateFragment)) {
                 consumer(candidate);
                 usedVersionFragments.add(candidateFragment);

--- a/lib/versioning.js
+++ b/lib/versioning.js
@@ -6,15 +6,17 @@ const SemVer = {
     sort: semver.sort,
     parse: semver.parse,
     valid: semver.valid,
-    range: (range, includePrerelease) => new semver.Range(range, {loose: true, includePrerelease})
+    range(range, includePrerelease) {
+        return new semver.Range(range, {loose: true, includePrerelease});
+    }
 }
 
 const Lexicographically = {
-    sort: function(versionsList) {
+    sort(versionsList) {
         return versionsList.sort()
     },
 
-    parse: function(version) {
+    parse(version) {
         return {
             major: version,
             minor: '0',
@@ -22,17 +24,17 @@ const Lexicographically = {
         }
     },
 
-    valid: function(version) {
+    valid() {
         return true;
     },
 
-    range: (range, includePrerelease) => {
+    range(range) {
         const re = new RegExp(range);
         return {
             toString: () => {
                 return `LexicographicVersionRange[${range}]`
             },
-            test: function(version) {
+            test(version) {
                 return re.test(version);
             },
             format: () => {
@@ -41,17 +43,23 @@ const Lexicographically = {
         };
     }
 }
-const OSGI_VERSION_REG_EXP = /^([0-9]+)(?:\.([0-9]+)(?:\.([0-9]+)(?:\.([0-9a-z_-]+))?)?)?$/i;
-const OSGI_RANGE_REG_EXP = /^([\[(])?([0-9]+(?:\.[0-9]+(?:\.[0-9]+(?:\.[0-9a-z_-]+)?)?)?)(?:,([0-9]+(?:\.[0-9]+(?:\.[0-9]+(?:\.[0-9a-z_-]+)?)?)?)([\])]))?$/i;
+const DIGITS ='[0-9]+';
+const OSGI_QUALIFIER = '[0-9a-z_-]+';
+const OSGI_VERSION = `(${DIGITS})(?:\.(${DIGITS})(?:\.(${DIGITS})(?:\.(${OSGI_QUALIFIER}))?)?)?`;
+const OSGI_VERSION_REG_EXP = new RegExp(`^${OSGI_VERSION}\$`, 'i');
+const OSGI_RANGE_START = '[\\[(]';
+const OSGI_RANGE_END = '[\\])]';
+const OSGI_RANGE = `(${OSGI_RANGE_START})?${OSGI_VERSION}(?:,${OSGI_VERSION}(${OSGI_RANGE_END}))?`;
+const OSGI_RANGE_REG_EXP = new RegExp(`^${OSGI_RANGE}\$`, 'i');
 const OSGI = {
 
-    compare: function(a, b) {
+    compare(a, b) {
         if (a > b) return 1;
         if (b > a) return -1;
         return 0;
     },
 
-    compareVersions: function (aVersion, bVersion) {
+    compareVersions(aVersion, bVersion) {
         const compareResults = [
             this.compare(aVersion.major, bVersion.major),
             this.compare(aVersion.minor, bVersion.minor),
@@ -63,7 +71,7 @@ const OSGI = {
         return compareResults.find(e => e !== 0) || 0;
     },
 
-    sort: function(versionsList) {
+    sort(versionsList) {
         return versionsList.sort((a, b) => {
             const aVersion = this.parse(a);
             const bVersion = this.parse(b);
@@ -71,38 +79,41 @@ const OSGI = {
         });
     },
 
-    parse: function(version) {
+    parse(version) {
         const match = version.match(OSGI_VERSION_REG_EXP);
         if (!match) {
             return null;
         }
-        return {
-            major: match[1],
-            minor: match[2] || '0',
-            patch: match[3] || '0',
-            // osgi specific alias for patch
-            micro: match[3] || '0',
-            qualifier: match[4] || ''
-        }
+        return this.versionFromMatch(match)
     },
 
-    valid: function(version) {
+    versionFromMatch(match, groupOffset = 0) {
+        if (match[groupOffset + 1] == null) {
+            return null;
+        }
+        return {
+            major: match[groupOffset + 1],
+            minor: match[groupOffset + 2] || '0',
+            patch: match[groupOffset + 3] || '0',
+            // osgi specific alias for patch
+            micro: match[groupOffset + 3] || '0',
+            qualifier: match[groupOffset + 4] || ''
+        };
+    },
+
+    valid(version) {
         return this.parse(version) !== null;
     },
 
-    range: function(range, includePrerelease) {
+    range(range) {
         const match = range.match(OSGI_RANGE_REG_EXP);
         if (!match) {
             return null;
         }
-        let lower = match[2]
+        const lower = this.versionFromMatch(match, 1);
         const lowerInclusive = match[1] === '[' || !match[1];
-        let upper = match[3];
-        const upperInclusive = match[4] === ']';
-        lower = this.parse(lower);
-        if (upper) {
-            upper = this.parse(upper);
-        }
+        const upper = this.versionFromMatch(match, 5);
+        const upperInclusive = match[10] === ']';
         return {
             test: version => {
                 version = this.parse(version);
@@ -135,4 +146,7 @@ const OSGI = {
     }
 }
 
+/**
+ * @type {Object.<SemVer|Lexicographically|OSGI, {valid(string): boolean,range(string, string): (null|{test(string): (boolean), format(): string, toString(): string}),sort(string[]): string[],parse(string): (null|{major: int, minor: int, patch: int})}>}
+ */
 module.exports = { SemVer, Lexicographically, OSGI}

--- a/lib/versioning.js
+++ b/lib/versioning.js
@@ -1,0 +1,138 @@
+"use strict";
+
+const semver = require('semver')
+
+const SemVer = {
+    sort: semver.sort,
+    parse: semver.parse,
+    valid: semver.valid,
+    range: (range, includePrerelease) => new semver.Range(range, {loose: true, includePrerelease})
+}
+
+const Lexicographically = {
+    sort: function(versionsList) {
+        return versionsList.sort()
+    },
+
+    parse: function(version) {
+        return {
+            major: version,
+            minor: '0',
+            patch: '0'
+        }
+    },
+
+    valid: function(version) {
+        return true;
+    },
+
+    range: (range, includePrerelease) => {
+        const re = new RegExp(range);
+        return {
+            toString: () => {
+                return `LexicographicVersionRange[${range}]`
+            },
+            test: function(version) {
+                return re.test(version);
+            },
+            format: () => {
+                return range;
+            }
+        };
+    }
+}
+const OSGI_VERSION_REG_EXP = /^([0-9]+)(?:\.([0-9]+)(?:\.([0-9]+)(?:\.([0-9a-z_-]+))?)?)?$/i;
+const OSGI_RANGE_REG_EXP = /^([\[(])?([0-9]+(?:\.[0-9]+(?:\.[0-9]+(?:\.[0-9a-z_-]+)?)?)?)(?:,([0-9]+(?:\.[0-9]+(?:\.[0-9]+(?:\.[0-9a-z_-]+)?)?)?)([\])]))?$/i;
+const OSGI = {
+
+    compare: function(a, b) {
+        if (a > b) return 1;
+        if (b > a) return -1;
+        return 0;
+    },
+
+    compareVersions: function (aVersion, bVersion) {
+        const compareResults = [
+            this.compare(aVersion.major, bVersion.major),
+            this.compare(aVersion.minor, bVersion.minor),
+            // OSGI versioning calls it "micro": https://www.eclipse.org/virgo/documentation/virgo-documentation-3.7.0.M01/docs/virgo-user-guide/html/ch02s02.html
+            this.compare(aVersion.micro, bVersion.micro)
+            // OSGI qualifiers are not used in comparisons.
+        ]
+        // `find` returns the 1st item satisfying, or undefined
+        return compareResults.find(e => e !== 0) || 0;
+    },
+
+    sort: function(versionsList) {
+        return versionsList.sort((a, b) => {
+            const aVersion = this.parse(a);
+            const bVersion = this.parse(b);
+            return this.compareVersions(aVersion, bVersion);
+        });
+    },
+
+    parse: function(version) {
+        const match = version.match(OSGI_VERSION_REG_EXP);
+        if (!match) {
+            return null;
+        }
+        return {
+            major: match[1],
+            minor: match[2] || '0',
+            patch: match[3] || '0',
+            // osgi specific alias for patch
+            micro: match[3] || '0',
+            qualifier: match[4] || ''
+        }
+    },
+
+    valid: function(version) {
+        return this.parse(version) !== null;
+    },
+
+    range: function(range, includePrerelease) {
+        const match = range.match(OSGI_RANGE_REG_EXP);
+        if (!match) {
+            return null;
+        }
+        let lower = match[2]
+        const lowerInclusive = match[1] === '[' || !match[1];
+        let upper = match[3];
+        const upperInclusive = match[4] === ']';
+        lower = this.parse(lower);
+        if (upper) {
+            upper = this.parse(upper);
+        }
+        return {
+            test: version => {
+                version = this.parse(version);
+                const lowerCompare = this.compareVersions(lower, version);
+                if (lowerCompare > 0) {
+                    return false;
+                }
+                if (lowerCompare === 0 && !lowerInclusive) {
+                    return false;
+                }
+                if (!upper) {
+                    return true;
+                }
+                const upperCompare = this.compareVersions(upper, version)
+                if (upperCompare > 0) {
+                    return true;
+                }
+                if (upperCompare === 0 && upperInclusive) {
+                    return true;
+                }
+                return false
+            },
+            format: () => {
+                return range;
+            },
+            toString: () => {
+                return `OSGIVersionRange[${range}]`;
+            }
+        };
+    }
+}
+
+module.exports = { SemVer, Lexicographically, OSGI}

--- a/test/extension.spec.js
+++ b/test/extension.spec.js
@@ -93,7 +93,5 @@ describe('antora maven content extension', function () {
             const updatedVars = expectVarUpdate();
             expect(updatedVars).to.deep.equal({playbook});
         })
-
-
     })
 });

--- a/test/version-selector.spec.js
+++ b/test/version-selector.spec.js
@@ -3,68 +3,180 @@ const expect = chai.expect
 global.td = require('testdouble')
 const tdChai = require('testdouble-chai');
 chai.use(tdChai(td));
-const semver = require('semver');
 
 const selectVersion = require('../lib/version-selector')
+const versioning = require('../lib/versioning')
 
-function createVersionRepoList(...versions) {
+function createVersionRepoList(scheme, ...versions) {
     // version selector expects descending order
-    return semver.sort(versions).reverse().map(version => {
+    return scheme.sort(versions).reverse().map(version => {
         return {version, repository: "https://www.example.com"};
     })
 }
 
 describe('version selector', function () {
 
-    it('should find exact version', function () {
-        let selection = []
-        selectVersion(
-            '1.0.0',
-            1,
-            'any',
-            createVersionRepoList('0.1.0', '1.0.0', '2.0.0', '2.1.0'),
+    describe('with a SemVer scheme', function () {
+
+        it('should find exact version', function () {
+            let selection = []
+            selectVersion(
+                versioning.SemVer,
+                '1.0.0',
+                1,
+                'any',
+                createVersionRepoList(versioning.SemVer, '0.1.0', '1.0.0', '2.0.0', '2.1.0'),
                 entry => selection.push(entry.version),
-            td.object()
-        )
-        expect(selection).to.have.members(['1.0.0'])
-    });
+                td.object()
+            )
+            expect(selection).to.have.members(['1.0.0'])
+        });
 
-    it('should find higher version', function () {
-        let selection = []
-        selectVersion(
-            '1.x.x',
-            1,
-            'any',
-            createVersionRepoList('0.1.0', '1.0.0', '1.1.1', '2.0.0', '2.1.0'),
-            entry => selection.push(entry.version),
-            td.object()
-        )
-        expect(selection).to.have.members(['1.1.1'])
-    });
+        it('should find higher version', function () {
+            let selection = []
+            selectVersion(
+                versioning.SemVer,
+                '1.x.x',
+                1,
+                'any',
+                createVersionRepoList(versioning.SemVer, '0.1.0', '1.0.0', '1.1.1', '2.0.0', '2.1.0'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['1.1.1'])
+        });
 
-    it('should find 2 highest versions', function () {
-        let selection = []
-        selectVersion(
-            '1.x.x',
-            2,
-            'any',
-            createVersionRepoList('0.1.0', '1.0.0', '1.1.1', '1.2.0', '2.0.0', '2.1.0'),
-            entry => selection.push(entry.version),
-            td.object()
-        )
-        expect(selection).to.have.members(['1.2.0', '1.1.1'])
-    });
+        it('should find 2 highest versions', function () {
+            let selection = []
+            selectVersion(
+                versioning.SemVer,
+                '1.x.x',
+                2,
+                'any',
+                createVersionRepoList(versioning.SemVer, '0.1.0', '1.0.0', '1.1.1', '1.2.0', '2.0.0', '2.1.0'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['1.2.0', '1.1.1'])
+        });
 
-    it('should find 2 highest major versions >= 1', function () {
-        let selection = []
-        selectVersion(
-            '>= 1',
-            2,
-            'major',
-            createVersionRepoList('0.1.0', '1.0.0', '1.1.1', '1.2.0', '2.0.0', '2.1.0', '2.1.1'),
-            entry => selection.push(entry.version),
-            td.object()
-        )
-        expect(selection).to.have.members(['2.1.1', '1.2.0'])
-    });
+        it('should find 2 highest major versions >= 1', function () {
+            let selection = []
+            selectVersion(
+                versioning.SemVer,
+                '>= 1',
+                2,
+                'major',
+                createVersionRepoList(versioning.SemVer, '0.1.0', '1.0.0', '1.1.1', '1.2.0', '2.0.0', '2.1.0', '2.1.1'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['2.1.1', '1.2.0'])
+        });
+    })
+
+
+    describe('with a lexicographical scheme', function () {
+
+        it('should find exact version', function () {
+            let selection = []
+            selectVersion(
+                versioning.Lexicographically,
+                '20/01',
+                1,
+                'any',
+                createVersionRepoList(versioning.Lexicographically, '19/01', '19/04', '19/08', '20/01', '21/00'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['20/01'])
+        });
+
+        it('should find higher version', function () {
+            let selection = []
+            selectVersion(
+                versioning.Lexicographically,
+                '2.*',
+                1,
+                'any',
+                createVersionRepoList(versioning.Lexicographically, '19/00', '19/04', '19/08', '20/00', '21/00'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['21/00'])
+        });
+
+        it('should find 2 highest versions', function () {
+            let selection = []
+            selectVersion(
+                versioning.Lexicographically,
+                '2.*',
+                2,
+                'any',
+                createVersionRepoList(versioning.Lexicographically, '19/00', '19/04', '19/08', '20/00', '21/00'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['21/00', '20/00'])
+        });
+    })
+
+    describe('with a OSGI scheme', function () {
+
+        it('should find exact version', function () {
+            let selection = []
+            selectVersion(
+                versioning.OSGI,
+                '[1.0.0,1.0.0]',
+                1,
+                'any',
+                createVersionRepoList(versioning.OSGI, '0.1.0', '1.0.0', '2.0.0', '2.1.0'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['1.0.0'])
+        });
+
+        it('should find higher version', function () {
+            let selection = []
+            selectVersion(
+                versioning.OSGI,
+                '[1,2)',
+                1,
+                'any',
+                createVersionRepoList(versioning.OSGI, '0.1.0', '1.0.0', '1.1.1', '2.0.0', '2.1.0'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['1.1.1'])
+        });
+
+        it('should find 2 highest versions below 2.0.0', function () {
+            let selection = []
+            selectVersion(
+                versioning.OSGI,
+                '[1,2)',
+                2,
+                'any',
+                createVersionRepoList(versioning.OSGI, '0.1.0', '1.0.0.RANDOM', '1.1.1.META', '1.2.0', '2.0.0.QUALIFier', '2.1.0'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['1.2.0', '1.1.1.META'])
+        });
+
+        it('should find 2 highest major versions >= 1', function () {
+            let selection = []
+            selectVersion(
+                versioning.OSGI,
+                '1',
+                2,
+                'major',
+                createVersionRepoList(versioning.OSGI, '0.1.0', '1.0.0', '1.1.1', '1.2.0', '2.0.0', '2.1.0', '2.1.1'),
+                entry => selection.push(entry.version),
+                td.object()
+            )
+            expect(selection).to.have.members(['2.1.1', '1.2.0'])
+        });
+    })
 });


### PR DESCRIPTION
This adds a OSGI centric versioning scheme as well as a plain text versioning scheme with SemVer still being the recommended default.

feat: pass through given `edit_url`

fix: either pass through `edit_url` or suppress it